### PR TITLE
Add Grype Version Control

### DIFF
--- a/.github/workflows/default_test_security-scan-workflow.yml
+++ b/.github/workflows/default_test_security-scan-workflow.yml
@@ -30,12 +30,3 @@ on:
 jobs:
   Default_Test-PlatSec-Workflow:
     uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
-  Inputs_Test-PlatSec-Workflow:
-    uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
-    with:
-      base_image_build: true
-      base_dockerfile_path: './test'
-      base_dockerfile_name: 'Dockerfile.base'
-      build_arg: '--build-arg BASE_IMAGE="localbuild/baseimage:latest"'
-      dockerfile_path: './test'
-      dockerfile_name: 'Dockerfile.main'

--- a/.github/workflows/inputs_test_security-scan-workflow.yml
+++ b/.github/workflows/inputs_test_security-scan-workflow.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# The default values used in the docker build commands are the root
+# directory '.' and the dockerfile name of 'Dockerfile'. If there is 
+# a need to change these do so in your local workflow template (this file) and
+# change them there. HINT: Look at the bottom of this file.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and generates an
+# SBOM via Anchore's Syft tool
+
+# For more information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+
+# For more information about the Anchore SBOM tool, Syft, see
+# https://github.com/anchore/syft
+
+name: ConsoleDot Platform Security Scan
+
+on:
+  push:
+    branches: [ "main", "master", "security-compliance" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main", "master", "security-compliance" ]
+
+jobs:
+  Inputs_Test-PlatSec-Workflow:
+    uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
+    with:
+      base_image_build: true
+      base_dockerfile_path: './test'
+      base_dockerfile_name: 'Dockerfile.base'
+      build_arg: '--build-arg BASE_IMAGE="localbuild/baseimage:latest"'
+      dockerfile_path: './test'
+      dockerfile_name: 'Dockerfile.main'

--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -23,7 +23,6 @@ name: ConsoleDot Platform Security Scan - Reusable Workflow
 env: 
   GRYPE_VERSION: "v0.63.0" #"v0.65.0"
   SYFT_VERSION: "v0.86.1"
-  SCAN_ACTION_VERSION: "v3.3.6"   # https://github.com/anchore/scan-action/
   GRYPE_ARTIFACTS_DIR: $GRYPE_ARTIFACTS_DIR
 
 on:
@@ -79,7 +78,7 @@ jobs:
     - name: Build the Docker image
       run: docker build ${{ inputs.build_arg }} ${{ inputs.dockerfile_path }} --file ${{ inputs.dockerfile_path }}/${{ inputs.dockerfile_name }} --tag localbuild/testimage:latest
     - name: Install Anchore Grype
-      uses: anchore/scan-action/download-grype@ ${{ env.SCAN_ACTION_VERSION }}
+      uses: anchore/scan-action/download-grype@v3.3.6
       with:
         grype-version: ${{env.GRYPE_VERSION}}
     - name: Scan image for Vulnerabilities
@@ -93,8 +92,7 @@ jobs:
         name: grype-vuln-artifacts
         path: $GRYPE_ARTIFACTS_DIR
     - name: Grade Container Image (Pass or Fail)
-      uses: anchore/scan-action@ ${{ env.SCAN_ACTION_VERSION }}
-      # id: scan
+      uses: anchore/scan-action@v3.3.6
       with:
         image: "localbuild/testimage:latest"
         only-fixed: true

--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -80,7 +80,7 @@ jobs:
       run: docker build ${{ inputs.build_arg }} ${{ inputs.dockerfile_path }} --file ${{ inputs.dockerfile_path }}/${{ inputs.dockerfile_name }} --tag localbuild/testimage:latest
     - name: Install Anchore Grype
     #   run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $GRYPE_VERSION
-      uses: anchore/scan-action/download-grype@${{ env.SCAN_ACTION_VERSION }}
+      uses: anchore/scan-action/download-grype@v3.3.6
       # id: grype
       with:
         grype-version: ${{env.GRYPE_VERSION}}
@@ -95,7 +95,7 @@ jobs:
         name: grype-vuln-artifacts
         path: $GRYPE_ARTIFACTS_DIR
     - name: Grade Container Image (Pass or Fail)
-      uses: anchore/scan-action@${{ env.SCAN_ACTION_VERSION }}
+      uses: anchore/scan-action@v3.3.6
       id: scan
       with:
         image: "localbuild/testimage:latest"

--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -21,8 +21,9 @@
 name: ConsoleDot Platform Security Scan - Reusable Workflow 
 
 env: 
-  GRYPE_VERSION: "v0.65.0"
+  GRYPE_VERSION: "v0.63.0" #"v0.65.0"
   SYFT_VERSION: "v0.86.1"
+  SCAN_ACTION_VERSION: "v3.3.6"
   GRYPE_ARTIFACTS_DIR: $GRYPE_ARTIFACTS_DIR
 
 on:
@@ -78,7 +79,11 @@ jobs:
     - name: Build the Docker image
       run: docker build ${{ inputs.build_arg }} ${{ inputs.dockerfile_path }} --file ${{ inputs.dockerfile_path }}/${{ inputs.dockerfile_name }} --tag localbuild/testimage:latest
     - name: Install Anchore Grype
-      run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $GRYPE_VERSION
+    #   run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $GRYPE_VERSION
+      uses: anchore/scan-action/download-grype@${{ env.SCAN_ACTION_VERSION }}
+      # id: grype
+      with:
+        grype-version: ${{env.GRYPE_VERSION}}
     - name: Scan image for Vulnerabilities
       run: |
         mkdir $GRYPE_ARTIFACTS_DIR
@@ -90,11 +95,11 @@ jobs:
         name: grype-vuln-artifacts
         path: $GRYPE_ARTIFACTS_DIR
     - name: Grade Container Image (Pass or Fail)
-      uses: anchore/scan-action@24fd7c9060f3c96848dd1929fac8d796fb5ae4b4
+      uses: anchore/scan-action@${{ env.SCAN_ACTION_VERSION }}
       id: scan
       with:
         image: "localbuild/testimage:latest"
-        grype-version: ${{env.GRYPE_VERSION}}
+        # grype-version: ${{env.GRYPE_VERSION}}
         only-fixed: true
         fail-build: true
         severity-cutoff: high

--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -23,7 +23,7 @@ name: ConsoleDot Platform Security Scan - Reusable Workflow
 env: 
   GRYPE_VERSION: "v0.63.0" #"v0.65.0"
   SYFT_VERSION: "v0.86.1"
-  SCAN_ACTION_VERSION: "v3.3.6"
+  SCAN_ACTION_VERSION: "v3.3.6"   # https://github.com/anchore/scan-action/
   GRYPE_ARTIFACTS_DIR: $GRYPE_ARTIFACTS_DIR
 
 on:
@@ -79,9 +79,7 @@ jobs:
     - name: Build the Docker image
       run: docker build ${{ inputs.build_arg }} ${{ inputs.dockerfile_path }} --file ${{ inputs.dockerfile_path }}/${{ inputs.dockerfile_name }} --tag localbuild/testimage:latest
     - name: Install Anchore Grype
-    #   run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $GRYPE_VERSION
-      uses: anchore/scan-action/download-grype@v3.3.6
-      # id: grype
+      uses: anchore/scan-action/download-grype@${{ env.SCAN_ACTION_VERSION }}
       with:
         grype-version: ${{env.GRYPE_VERSION}}
     - name: Scan image for Vulnerabilities
@@ -95,11 +93,10 @@ jobs:
         name: grype-vuln-artifacts
         path: $GRYPE_ARTIFACTS_DIR
     - name: Grade Container Image (Pass or Fail)
-      uses: anchore/scan-action@v3.3.6
+      uses: anchore/scan-action@${{ env.SCAN_ACTION_VERSION }}
       id: scan
       with:
         image: "localbuild/testimage:latest"
-        # grype-version: ${{env.GRYPE_VERSION}}
         only-fixed: true
         fail-build: true
         severity-cutoff: high

--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -21,7 +21,7 @@
 name: ConsoleDot Platform Security Scan - Reusable Workflow 
 
 env: 
-  GRYPE_VERSION: "v0.63.0" #"v0.65.0"
+  GRYPE_VERSION: "v0.65.0"
   SYFT_VERSION: "v0.86.1"
   GRYPE_ARTIFACTS_DIR: $GRYPE_ARTIFACTS_DIR
 

--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Build the Docker image
       run: docker build ${{ inputs.build_arg }} ${{ inputs.dockerfile_path }} --file ${{ inputs.dockerfile_path }}/${{ inputs.dockerfile_name }} --tag localbuild/testimage:latest
     - name: Install Anchore Grype
-      uses: anchore/scan-action/download-grype@${{ env.SCAN_ACTION_VERSION }}
+      uses: anchore/scan-action/download-grype@ ${{ env.SCAN_ACTION_VERSION }}
       with:
         grype-version: ${{env.GRYPE_VERSION}}
     - name: Scan image for Vulnerabilities
@@ -93,8 +93,8 @@ jobs:
         name: grype-vuln-artifacts
         path: $GRYPE_ARTIFACTS_DIR
     - name: Grade Container Image (Pass or Fail)
-      uses: anchore/scan-action@${{ env.SCAN_ACTION_VERSION }}
-      id: scan
+      uses: anchore/scan-action@ ${{ env.SCAN_ACTION_VERSION }}
+      # id: scan
       with:
         image: "localbuild/testimage:latest"
         only-fixed: true


### PR DESCRIPTION
### Adding Proper Grype Version Control Support
- The reusable workflow has been updated to use the `anchore/scan-action/download-grype` GH Action. Which allow us to properly control the version of Grype we use for security scanning. 

- Additionally, the workflow tests have been split into two files to more accurately represent Git Repos that need to scan mutiple Dockerfiles.