### PR TITLE
Add New Input Variables

### DIFF
--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -73,17 +73,17 @@ on:
       only_fixed:
         description: 'Set whether to output only vulnerabilities with fixes.'
         default: true
-        required: true
+        required: false
         type: boolean
       fail_on_vulns:
         description: 'Set whether the job should fail if vulnerabilities are found. (based on severity_fail_cutoff)'
         default: true
-        required: true
+        required: false
         type: boolean
       severity_fail_cutoff:
         description: 'Set the severity level at which the job should fail.'
         default: 'high'
-        required: true
+        required: false
         type: string
 
 permissions:

--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -70,6 +70,21 @@ on:
         default: 'Dockerfile.base'
         required: false
         type: string
+      only_fixed:
+        description: 'Set whether to output only vulnerabilities with fixes.'
+        default: true
+        required: true
+        type: boolean
+      fail_on_vulns:
+        description: 'Set whether the job should fail if vulnerabilities are found. (based on severity_fail_cutoff)'
+        default: true
+        required: true
+        type: boolean
+      severity_fail_cutoff:
+        description: 'Set the severity level at which the job should fail.'
+        default: 'high'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -105,9 +120,9 @@ jobs:
       uses: anchore/scan-action@v3.6.4
       with:
         image: "localbuild/testimage:latest"
-        only-fixed: true
-        fail-build: true
-        severity-cutoff: high
+        only-fixed: ${{ inputs.only_fixed }}
+        fail-build: ${{ inputs.fail_on_vulns }}
+        severity-cutoff: ${{ inputs.severity_fail_cutoff }}
         output-format: table
 
   Anchore-Syft-SBOM-Scan:

--- a/.github/workflows/test_security-scan-workflow.yml
+++ b/.github/workflows/test_security-scan-workflow.yml
@@ -42,4 +42,4 @@ jobs:
   Build_Fail_Test-PlatSec-Workflow:
     uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
     with:
-      fail-build: false
+      fail_on_vulns: false

--- a/.github/workflows/test_security-scan-workflow.yml
+++ b/.github/workflows/test_security-scan-workflow.yml
@@ -39,7 +39,4 @@ jobs:
       build_arg: '--build-arg BASE_IMAGE="localbuild/baseimage:latest"'
       dockerfile_path: './test'
       dockerfile_name: 'Dockerfile.main'
-  Build_Fail_Test-PlatSec-Workflow:
-    uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
-    with:
       fail_on_vulns: false

--- a/.github/workflows/test_security-scan-workflow.yml
+++ b/.github/workflows/test_security-scan-workflow.yml
@@ -39,3 +39,7 @@ jobs:
       build_arg: '--build-arg BASE_IMAGE="localbuild/baseimage:latest"'
       dockerfile_path: './test'
       dockerfile_name: 'Dockerfile.main'
+  Build_Fail_Test-PlatSec-Workflow:
+    uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
+    with:
+      fail-build: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a mock Dockerfile for testing ".github/workflows/platsec-security-workflow.yml"
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1696517598
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a mock Dockerfile for testing ".github/workflows/platsec-security-workflow.yml"
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1696517598
 
 WORKDIR /usr/src/app
 

--- a/security-workflow-template.yml
+++ b/security-workflow-template.yml
@@ -44,3 +44,6 @@ jobs:
     #   base_dockerfile_path: './test'
     #   base_dockerfile_name: 'Dockerfile.base'
     #   build_arg: '--build-arg BASE_IMAGE="localbuild/baseimage:latest"'
+    #   only_fixed: true
+    #   fail_on_vulns: true
+    #   severity_fail_cutoff: high 

--- a/test/Dockerfile.base
+++ b/test/Dockerfile.base
@@ -1,6 +1,6 @@
 # This is a mock Dockerfile for testing ".github/workflows/platsec-security-workflow.yml"
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1696517598
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Overview

Added the following new `Input Variables` to allow for more granular control by the App Teams.

- `only_fixed` | *(default: true)* | Set whether to output only vulnerabilities with fixes.
- `fail_on_vulns` | *(default: true)* |  Set whether the job should fail if vulnerabilities are found. 
   - Based on *"severity_fail_cutoff"*
- `severity_fail_cutoff`| *(default: high)* | Set the severity level at which the job should fail.