### PR TITLE
Refining False Positive Integration to the GH Workflow

### DIFF
--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -22,8 +22,9 @@ name: ConsoleDot Platform Security Scan - Reusable Workflow
 
 env: 
   GRYPE_VERSION: "v0.74.4"
-  SYFT_VERSION: "v0.103.1"
+  SYFT_VERSION: "v0.94.0"
   GRYPE_ARTIFACTS_DIR: $GRYPE_ARTIFACTS_DIR
+  SYFT_ARTIFACTS_DIR: $SYFT_ARTIFACTS_DIR
 
 on:
   workflow_call:
@@ -92,7 +93,7 @@ permissions:
 jobs:
   Anchore-Grype-Vulnerability-Scan:
     permissions:
-      contents: read    # for actions/checkout to fetch code
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
     - name: Check out the code
@@ -103,32 +104,32 @@ jobs:
     - name: Build the Docker image
       run: docker build ${{ inputs.build_arg }} ${{ inputs.dockerbuild_path }} --file ${{ inputs.dockerfile_path }}/${{ inputs.dockerfile_name }} --tag localbuild/testimage:latest
     - name: Install Anchore Grype
-      uses: anchore/scan-action/download-grype@v3.6.4
-      with:
-        grype-version: ${{env.GRYPE_VERSION}}
+      run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin $GRYPE_VERSION
     - name: Scan image for Vulnerabilities
       run: |
         mkdir $GRYPE_ARTIFACTS_DIR
         curl -sSfL https://raw.githubusercontent.com/RedHatInsights/platform-security-gh-workflow/master/false_positives/grype-false-positives.yml > grype.yml
         grype -v -c grype.yml -o table localbuild/testimage:latest > $GRYPE_ARTIFACTS_DIR/grype-vuln-results-full-${{ inputs.dockerfile_name }}.txt
+        grype -v -c grype.yml -o json localbuild/testimage:latest > $GRYPE_ARTIFACTS_DIR/grype-vuln-results-full-${{ inputs.dockerfile_name }}.json
         grype -v -c grype.yml -o table --only-fixed localbuild/testimage:latest > $GRYPE_ARTIFACTS_DIR/grype-vuln-results-fixable-${{ inputs.dockerfile_name }}.txt
+        grype -v -c grype.yml -o json --only-fixed localbuild/testimage:latest > $GRYPE_ARTIFACTS_DIR/grype-vuln-results-fixable-${{ inputs.dockerfile_name }}.json
     - name: Provide Grype Vulnerability Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: grype-vuln-artifacts-${{ inputs.dockerfile_name }}
         path: $GRYPE_ARTIFACTS_DIR
     - name: Grade Container Image (Pass or Fail)
-      uses: anchore/scan-action@v3.6.4
-      with:
-        image: "localbuild/testimage:latest"
-        only-fixed: ${{ inputs.only_fixed }}
-        fail-build: ${{ inputs.fail_on_vulns }}
-        severity-cutoff: ${{ inputs.severity_fail_cutoff }}
-        output-format: table
+      run: |
+        if [ "${{ inputs.fail_on_vulns }}" = true ]; then
+          grype -v -c grype.yml --only-fixed --fail-on ${{ inputs.severity_fail_cutoff }} localbuild/testimage:latest
+        else
+          echo "Fail on vulnerabilities is set to False. Skipping fail on vulnerabilities."
+          grype -v -c grype.yml --only-fixed localbuild/testimage:latest
+        fi
 
   Anchore-Syft-SBOM-Scan:
     permissions:
-      contents: read     # for actions/checkout to fetch code
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
@@ -141,9 +142,12 @@ jobs:
     - name: Install Anchore Syft
       run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin $SYFT_VERSION
     - name: Scan the image and generate SBOM
-      run: syft -v localbuild/testimage:latest > syft-sbom-results-${{ inputs.dockerfile_name }}.txt
+      run: |
+        mkdir $SYFT_ARTIFACTS_DIR
+        syft -v -o table localbuild/testimage:latest > $SYFT_ARTIFACTS_DIR/syft-sbom-results-${{ inputs.dockerfile_name }}.txt
+        syft -v -o json localbuild/testimage:latest > $SYFT_ARTIFACTS_DIR/syft-sbom-results-${{ inputs.dockerfile_name }}.json
     - name: Provide Syft SBOM Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: syft-sbom-artifacts-${{ inputs.dockerfile_name }}
-        path: syft-sbom-results-${{ inputs.dockerfile_name }}.txt
+        path: $SYFT_ARTIFACTS_DIR

--- a/false_positives/grype-false-positives.yml
+++ b/false_positives/grype-false-positives.yml
@@ -31,10 +31,3 @@ ignore:
       version: 39.2.0
       type: python
       location: "/usr/lib/python3.6/site-packages/**"
-
-# TESTING
-  - vulnerability: CVE-2023-3446
-    package:
-      name: openssl-libs 
-      version: 1:1.1.1k-9.el8_7
-      type: rpm


### PR DESCRIPTION
## Overview
This update enables the `Security GitHub Workflow` to use our False Positive Tracker ([grype-false-positives.yml](https://github.com/RedHatInsights/platform-security-gh-workflow/blob/master/false_positives/grype-false-positives.yml)). 

Additionally, the output of both the `Syft` and `Grype` jobs provide `json` files in addition to the standard `text` files. These new `json` files provide more verbose data with regards to the SBOM and Vulnerability findings. 