### PR TITLE
Update False Positives for all RHEL-Based Images

### DIFF
--- a/false_positives/grype-false-positives.yml
+++ b/false_positives/grype-false-positives.yml
@@ -4,7 +4,7 @@ ignore:
     # justification: "https://access.redhat.com/errata/RHSA-2021:4455"
     package:
       name: pip
-      version: 9.0.3
+      # version: 9.0.3
       type: python
       location: "/usr/lib/python3.6/site-packages/**"
 
@@ -12,7 +12,7 @@ ignore:
     # justification: "https://access.redhat.com/errata/RHSA-2020:4432"
     package:
       name: pip
-      version: 9.0.3
+      # version: 9.0.3
       type: python
       location: "/usr/lib/python3.6/site-packages/**"
 
@@ -20,7 +20,7 @@ ignore:
     # justification: "Not affected - https://access.redhat.com/security/cve/cve-2023-5752"
     package: 
       name: pip
-      version: 9.0.3
+      # version: 9.0.3
       type: python
       location: "/usr/lib/python3.6/site-packages/**"
 
@@ -28,6 +28,6 @@ ignore:
     # justification: "https://access.redhat.com/errata/RHSA-2023:0835"
     package:
       name: setuptools
-      version: 39.2.0
+      # version: 39.2.0
       type: python
       location: "/usr/lib/python3.6/site-packages/**"

--- a/false_positives/tattler-false-positives.json
+++ b/false_positives/tattler-false-positives.json
@@ -1,25 +1,25 @@
 {
     "false_postives": [
         {
-            "images": ["insights-3scale", "turnpike-web", "cloudwatch-aggregator"],
+            "images": ["quay.io/repository/cloudservices"],
             "vulnerability_id": "GHSA-5xp3-jfq3-5q8x",
             "package": "pip",
             "notes": "https://access.redhat.com/errata/RHSA-2021:4455"
         },
         {
-            "images": ["insights-3scale", "turnpike-web"],
+            "images": ["quay.io/repository/cloudservices"],
             "vulnerability_id": "GHSA-gpvv-69j7-gwj8",
             "package": "pip",
             "notes": "https://access.redhat.com/errata/RHSA-2020:4432"
         },
         {
-            "images": ["insights-3scale", "turnpike-web", "cloudwatch-aggregator"],
+            "images": ["quay.io/repository/cloudservices"],
             "vulnerability_id": "GHSA-mq26-g339-26xf",
             "package": "pip",
             "notes": "Not affected - https://access.redhat.com/security/cve/cve-2023-5752"
         },
         {
-            "images": ["insights-3scale", "turnpike-web"],
+            "images": ["quay.io/repository/cloudservices"],
             "vulnerability_id": "GHSA-r9hx-vwmv-q579",
             "package": "setuptools",
             "notes": "https://access.redhat.com/errata/RHSA-2023:0835"


### PR DESCRIPTION
## Overview

Updating both FP Trackers to account for all system we scan are RHEL-Based

- `quay.io/repository/cloudservices` -  All quay images we scan are using UBI8 (RHEL)
- `version` - is commented out as images we scan are using UBI8 (RHEL) and have received security-backports 