### PR TITLE
fix: add commit hash to image tag

### DIFF
--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -3,7 +3,7 @@
 set -exv
 
 IMAGE=$1
-IMAGE_TAG="security-scan"
+IMAGE_TAG="security-scan-${GIT_COMMIT::10}"
 DOCKERFILE_LOCATION=$2
 IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
 


### PR DESCRIPTION
 - Adds short git commit hash to image tag to avoid collisions on parallel runs