### PR TITLE
[Main Script] Deactivate cache on podman builds

### DIFF
--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -3,7 +3,7 @@
 set -exv
 
 IMAGE=$1
-IMAGE_TAG="security-scan-${GIT_COMMIT::10}"
+IMAGE_TAG="security-scan"
 DOCKERFILE_LOCATION=$2
 IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
 
@@ -51,7 +51,7 @@ function podman_build {
     podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned
-    podman build --pull=true -f ${DOCKERFILE_NAME} -t "${IMAGE}:${IMAGE_TAG}" $DOCKERFILE_LOCATION
+    podman build --pull=true --no-cache -f ${DOCKERFILE_NAME} -t "${IMAGE}:${IMAGE_TAG}" $DOCKERFILE_LOCATION
     podman save -o "${TMP_JOB_DIR}/${IMAGE_ARCHIVE}" "${IMAGE}:${IMAGE_TAG}"
 
     # Clean up / Remove Container Image


### PR DESCRIPTION
## Overview

Pushing @Victoremepunto updates from `Beta` to `Main`

----
[BETA] Deactivate cache on podman builds https://github.com/RedHatInsights/platform-security-gh-workflow/pull/39

- Deactivates caching to avoid collisions when deleting the image built
- Rolls back change introduced in https://github.com/RedHatInsights/platform-security-gh-workflow/pull/38