### PR TITLE
Moving Jenkins Script Variables to Initialize Later in Execution

### DIFF
--- a/jenkins/beta-testing-security-scan.sh
+++ b/jenkins/beta-testing-security-scan.sh
@@ -7,22 +7,8 @@
 
 set -exv
 
-IMAGE=$1
-IMAGE_TAG="security-scan"
-DOCKERFILE_LOCATION=$2
-IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
-
 SYFT_VERSION="v0.94.0"
 GRYPE_VERSION="v0.74.4"
-
-# (Severity Options: negligible, low, medium, high, critical)
-FAIL_ON_SEVERITY=$3
-
-# Build on Podman or Docker
-PODMAN_OR_DOCKER=${4:-podman}
-
-# Dockerfile Name
-DOCKERFILE_NAME=${5:-Dockerfile}
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -44,6 +30,20 @@ function job_cleanup() {
 }
 
 trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+IMAGE=$1
+IMAGE_TAG="security-scan"
+DOCKERFILE_LOCATION=$2
+IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
+
+# (Severity Options: negligible, low, medium, high, critical)
+FAIL_ON_SEVERITY=$3
+
+# Build on Podman or Docker
+PODMAN_OR_DOCKER=${4:-podman}
+
+# Dockerfile Name
+DOCKERFILE_NAME=${5:-Dockerfile}
 
 function podman_build {
     # Set up Podman Config

--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -2,22 +2,8 @@
 
 set -exv
 
-IMAGE=$1
-IMAGE_TAG="security-scan"
-DOCKERFILE_LOCATION=$2
-IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
-
 SYFT_VERSION="v0.94.0"
 GRYPE_VERSION="v0.74.4"
-
-# (Severity Options: negligible, low, medium, high, critical)
-FAIL_ON_SEVERITY=$3
-
-# Build on Podman or Docker
-PODMAN_OR_DOCKER=${4:-podman}
-
-# Dockerfile Name
-DOCKERFILE_NAME=${5:-Dockerfile}
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -39,6 +25,20 @@ function job_cleanup() {
 }
 
 trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+IMAGE=$1
+IMAGE_TAG="security-scan"
+DOCKERFILE_LOCATION=$2
+IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
+
+# (Severity Options: negligible, low, medium, high, critical)
+FAIL_ON_SEVERITY=$3
+
+# Build on Podman or Docker
+PODMAN_OR_DOCKER=${4:-podman}
+
+# Dockerfile Name
+DOCKERFILE_NAME=${5:-Dockerfile}
 
 function podman_build {
     # Set up Podman Config


### PR DESCRIPTION
## Overview

The variables in the Jenkins Scripts (`main` & `beta`) have been moving to Initialize later in script's execution. There reason for this is due to the `DOCKERFILE_LOCATION` not being properly set if using a sub-directory in the `$TMP_JOB_DIR`.