### PR TITLE
Adding SetupTools FP for Python 3.11

### DIFF
--- a/false_positives/grype-false-positives.yml
+++ b/false_positives/grype-false-positives.yml
@@ -28,6 +28,13 @@ ignore:
       type: python
       location: "/usr/lib/python3*/site-packages/**"
 
+  - vulnerability: GHSA-cx63-2mw6-8hw5
+    # justification: "CVE-2024-6345 | Fixed (Backport) - https://access.redhat.com/security/cve/cve-2024-6345"
+    package:
+      name: setuptools
+      type: python
+      location: "/usr/lib/python3.11/site-packages/**"
+
   - vulnerability: GHSA-25w4-hfqg-4r52
     # justification: "CVE-2023-5675 | Fixed (Backport) - https://access.redhat.com/security/cve/CVE-2023-5675"
     package:

--- a/false_positives/tattler-false-positives.json
+++ b/false_positives/tattler-false-positives.json
@@ -25,6 +25,12 @@
             "notes": "CVE-2022-40897 | Fixed (Backport) - https://access.redhat.com/security/cve/CVE-2022-40897"
         },
         {
+            "images": ["insights-engine"],
+            "vulnerability_id": "GHSA-cx63-2mw6-8hw5",
+            "package": "setuptools",
+            "notes": "CVE-2024-6345 | Fixed (Backport) - https://access.redhat.com/security/cve/cve-2024-6345"
+        },
+        {
             "images": ["policies-engine"],
             "vulnerability_id": "GHSA-25w4-hfqg-4r52",
             "package": "quarkus-resteasy-reactive-common",


### PR DESCRIPTION
 ## Overview
 
**False Addition:**

```
  - vulnerability: 
             CVE-2024-6345
             GHSA-cx63-2mw6-8hw5
    justification: 
            Fixed (Backport)
            https://access.redhat.com/security/cve/cve-2024-6345
    package:
      name: setuptools
      type: python
      location: "/usr/lib/python3.11/site-packages/*
```