### PR TITLE
[FP Update] Update package location for "GHSA-cx63-2mw6-8hw5"

### DIFF
--- a/false_positives/grype-false-positives.yml
+++ b/false_positives/grype-false-positives.yml
@@ -33,7 +33,7 @@ ignore:
     package:
       name: setuptools
       type: python
-      location: "/usr/lib/python3.11/site-packages/**"
+      location: "/usr/lib/python3*/site-packages/**"
 
   - vulnerability: GHSA-25w4-hfqg-4r52
     # justification: "CVE-2023-5675 | Fixed (Backport) - https://access.redhat.com/security/cve/CVE-2023-5675"


### PR DESCRIPTION
### Overview

The install `location` has been update to support all versions of python3, as RH has patched all RPM versions for RHEL 8 & RHEL 9.
   - https://access.redhat.com/security/cve/cve-2024-6345

#### Update False Positive
```
  - vulnerability: 
             CVE-2024-6345
             GHSA-cx63-2mw6-8hw5
    justification: 
            Fixed (Backport)
            https://access.redhat.com/security/cve/cve-2024-6345
    package:
      name: setuptools
      type: python
      location: "/usr/lib/python3*/site-packages/*
```