### PR TITLE
Update Syft and Grype Version for GL Jenkins Script

### DIFF
--- a/jenkins/beta-testing-security-scan.sh
+++ b/jenkins/beta-testing-security-scan.sh
@@ -15,6 +15,7 @@ IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
 SYFT_VERSION="v1.12.2"
 GRYPE_VERSION="v0.80.1"
 
+# Sets Syft to Pretty Print JSON Ouputs
 SYFT_FORMAT_JSON_PRETTY=true
 
 # (Severity Options: negligible, low, medium, high, critical)


### PR DESCRIPTION
### Overview
---

- **Syft** = `v0.94.0` -> `v1.12.2`
- **Grype** = `v0.74.4` -> `v0.80.1`

---

- Vulnerability Scanning has been updated to use the SBOM generated from `Syft` as opposed to reevaluating the whole image again when running `Grype`. The additional context from the `syft` SBOM allows for better performance and more accurate scans. 

- This update have been tested (and was successful) against repos using the `beta` version of the security-scanning script. 