### PR TITLE
login to brew.registry.redhat.io

### DIFF
--- a/jenkins/beta-testing-security-scan.sh
+++ b/jenkins/beta-testing-security-scan.sh
@@ -56,6 +56,7 @@ function podman_build {
 
     # Log into Red Hat and Quay.io Container Registries
     podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+    podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
     podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned
@@ -73,6 +74,7 @@ function docker_build {
 
     # Log into Red Hat and Quay.io Container Registries
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+    DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned

--- a/jenkins/beta-testing-security-scan.sh
+++ b/jenkins/beta-testing-security-scan.sh
@@ -11,6 +11,7 @@ IMAGE=$1
 IMAGE_TAG="security-scan"
 DOCKERFILE_LOCATION=$2
 IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
+BREW_REGISTRY_ENABLED="${BREW_REGISTRY_ENABLED:-}"
 
 SYFT_VERSION="v1.12.2"
 GRYPE_VERSION="v0.80.1"
@@ -56,7 +57,9 @@ function podman_build {
 
     # Log into Red Hat and Quay.io Container Registries
     podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-    podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
+    if [[ -n "$BREW_REGISTRY_ENABLED" ]]; then
+      podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
+    fi
     podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned
@@ -74,7 +77,9 @@ function docker_build {
 
     # Log into Red Hat and Quay.io Container Registries
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-    DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
+    if [[ -n "$BREW_REGISTRY_ENABLED" ]]; then
+      DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
+    fi
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned

--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -51,6 +51,7 @@ function podman_build {
 
     # Log into Red Hat and Quay.io Container Registries
     podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+    podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
     podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned
@@ -68,6 +69,7 @@ function docker_build {
 
     # Log into Red Hat and Quay.io Container Registries
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+    DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned

--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -51,7 +51,6 @@ function podman_build {
 
     # Log into Red Hat and Quay.io Container Registries
     podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-    podman login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
     podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned
@@ -69,7 +68,6 @@ function docker_build {
 
     # Log into Red Hat and Quay.io Container Registries
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
-    DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" brew.registry.redhat.io
     DOCKER_CONFIG=$DOCKER_CONF docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
     # Build Container Image and save to Archive to be scanned


### PR DESCRIPTION
As part of updating the Builder stage images of our Go projects, we need to use images from brew, but the scanner fails as it can't pull the images. Should work with the registry creds