### PR TITLE
Update grype-false-positives

### DIFF
--- a/false_positives/grype-false-positives.yml
+++ b/false_positives/grype-false-positives.yml
@@ -21,3 +21,10 @@ match-upstream-kernel-headers: true
 #       version: 23.2.1
 #       type: python
 #       location: "/usr/lib/python3.12/site-packages/**"
+
+ignore:
+  - reason: "The file sample32.macho is a test file that is not used within VMAAS"
+    package:
+      name: stdlib
+      type: go-module
+      location: "/vmaas/go/pkg/mod/github.com/gabriel-vasile/mimetype@v1.4.6/testdata/sample32.macho"


### PR DESCRIPTION
### Overview
---
The file `sample32.macho` within the test suite for `mimetype` is pulled into VMAAS during the build process. This file is not used or called by VMAAS.

Due this just being a unused test file, HCM Security is flagging this as a False Positive. 