### PR TITLE
[BETA] Adding Vulnerability Console Output to Jenkins Jobs

### DIFF
--- a/jenkins/beta-testing-security-scan.sh
+++ b/jenkins/beta-testing-security-scan.sh
@@ -139,9 +139,19 @@ $TMP_JOB_DIR/grype -v -o json --only-fixed "sbom:$WORKSPACE/artifacts/sbom-resul
     -c ${TMP_JOB_DIR}/grype-false-positives.yml \
     > $WORKSPACE/artifacts/vulnerability-results-fixable-${IMAGE}.json
 
+set +e
 $TMP_JOB_DIR/grype -v -o table --only-fixed --fail-on $FAIL_ON_SEVERITY "sbom:$WORKSPACE/artifacts/sbom-results-${IMAGE}.json" \
     -c ${TMP_JOB_DIR}/grype-false-positives.yml \
     > $WORKSPACE/artifacts/vulnerability-results-fixable-${IMAGE}.txt
+TEST_RESULT=$?
+set -e
+if [ $TEST_RESULT -ne 0 ]; then
+    echo '==============================================='
+    echo '==== ✖ ERROR: Vulnerable packages detected ===='
+    echo '==============================================='
+    cat $WORKSPACE/artifacts/vulnerability-results-fixable-${IMAGE}.txt
+    exit $TEST_RESULT
+fi
 
 # Pass Jenkins dummy artifacts as it needs
 # an xml output to consider the job a success.


### PR DESCRIPTION
The message `discovered vulnerabilities at or above the severity threshold` is vague and does not provide sufficient information to the user. 

This update allows for listing specific vulnerable packages identified in the `/artifacts/vulnerability-results-fixable-${IMAGE}.txt` artifact file before concluding the Jenkins Job within the console. This will give users a clearer understanding of which packages are affected, in addition to having the data in the artifact files.