### PR TITLE
[MAIN] Updating Jobs to Support Git Commits on Anchore Tool Install

### DIFF
--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -10,6 +10,9 @@ IMAGE_ARCHIVE="${IMAGE}-${IMAGE_TAG}.tar"
 SYFT_VERSION="v1.12.2"
 GRYPE_VERSION="v0.80.1"
 
+SYFT_COMMIT_HASH="fcd5ec951de6b3fc1f1aa2a36968356d2eb22170"
+GRYPE_COMMIT_HASH="9fb219495a634d7ff9904154355b927223a66602"
+
 # Sets Syft to Pretty Print JSON Ouputs
 SYFT_FORMAT_JSON_PRETTY=true
 
@@ -89,10 +92,10 @@ else
 fi
 
 # Install Specific Version of Syft - SBOM Generator
-curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b $TMP_JOB_DIR $SYFT_VERSION
+curl -sSfL https://raw.githubusercontent.com/anchore/syft/${SYFT_COMMIT_HASH}/install.sh | sh -s -- -b $TMP_JOB_DIR $SYFT_VERSION
 
 # Install Specific Version of Grype - Vulnerability Scanner
-curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b $TMP_JOB_DIR $GRYPE_VERSION
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/${GRYPE_COMMIT_HASH}/install.sh | sh -s -- -b $TMP_JOB_DIR $GRYPE_VERSION
 
 # Download False Positives File from Platform Security GH Workflow Repo
 curl -sSfL https://raw.githubusercontent.com/RedHatInsights/platform-security-gh-workflow/master/false_positives/grype-false-positives.yml \


### PR DESCRIPTION
## Overview
This pull request enhances the Security Workflow in both Git and Jenkins by adding new variables. The primary purpose of this update is to lock the URL used for installing the tools Syft and Grype, ensuring that only a trusted version is accessed during the curl request process. This measure increases security and reliability by preventing the potential installation of unverified versions.

### New Variables
- `SYFT_COMMIT_HASH`
- `GRYPE_COMMIT_HASH`
