### PR TITLE
Adding RH Catalog Support to the Reusable Workflow

### DIFF
--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -31,6 +31,11 @@ env:
 
 on:
   workflow_call:
+    secrets:
+      RH_CATALOG_USERNAME:
+        required: false
+      RH_CATALOG_PASSWORD:
+        required: false
     inputs:
       # Defaults
       dockerbuild_path: 
@@ -106,6 +111,13 @@ jobs:
     steps:
     - name: Check out the code
       uses: actions/checkout@v4
+    - name: Log in to Red Hat Catalog
+      run: |
+        if [[ -z "${{ secrets.RH_CATALOG_USERNAME }}" || -z "${{ secrets.RH_CATALOG_PASSWORD }}" ]]; then
+          echo "Skipping login: Red Hat credentials not set"
+          exit 0
+        fi
+        echo "${{ secrets.RH_CATALOG_USERNAME }}" | docker login registry.redhat.io -u "${{ secrets.RH_CATALOG_PASSWORD }}" --password-stdin
     - name: Build the Base Docker image
       if: ${{ inputs.base_image_build }}
       run: docker build ${{ inputs.base_dockerbuild_path }} --file ${{ inputs.base_dockerfile_path }}/${{ inputs.base_dockerfile_name}} --tag localbuild/baseimage:latest
@@ -145,6 +157,13 @@ jobs:
     steps:
     - name: Checkout the code
       uses: actions/checkout@v4
+    - name: Log in to Red Hat Catalog
+      run: |
+        if [[ -z "${{ secrets.RH_CATALOG_USERNAME }}" || -z "${{ secrets.RH_CATALOG_PASSWORD }}" ]]; then
+          echo "Skipping login: Red Hat credentials not set"
+          exit 0
+        fi
+        echo "${{ secrets.RH_CATALOG_USERNAME }}" | docker login registry.redhat.io -u "${{ secrets.RH_CATALOG_PASSWORD }}" --password-stdin
     - name: Build the Base Docker image
       if: ${{ inputs.base_image_build }}
       run: docker build ${{ inputs.base_dockerbuild_path }} --file ${{ inputs.base_dockerfile_path }}/${{ inputs.base_dockerfile_name}} --tag localbuild/baseimage:latest

--- a/.github/workflows/test_security-scan-workflow.yml
+++ b/.github/workflows/test_security-scan-workflow.yml
@@ -30,6 +30,10 @@ on:
 jobs:
   Default_Test-PlatSec-Workflow:
     uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
+    # secrets:
+    #   RH_CATALOG_USERNAME: ${{ secrets.RH_CATALOG_USERNAME }}
+    #   RH_CATALOG_PASSWORD: ${{ secrets.RH_CATALOG_PASSWORD }}
+
   Inputs_Test-PlatSec-Workflow:
     uses: ./.github/workflows/platsec-security-scan-reusable-workflow.yml
     with:


### PR DESCRIPTION
### Overview
---
Adding the ability, within the GitHub Reusable Workflow,  to authenticate with the RH Catalog to pull base-image during the build process before scanning.

```
- name: Log in to Red Hat Catalog
      run: |
        if [[ -z "${{ secrets.RH_CATALOG_USERNAME }}" || -z "${{ secrets.RH_CATALOG_PASSWORD }}" ]]; then
          echo "Skipping login: Red Hat credentials not set"
          exit 0
        fi
        echo "${{ secrets.RH_CATALOG_USERNAME }}" | docker login 
        registry.redhat.io -u "${{ secrets.RH_CATALOG_PASSWORD }}" --password-stdin
```