### PR TITLE
Adding Severity Check Skip to Jenkins Jobs

### DIFF
--- a/jenkins/beta-testing-security-scan.sh
+++ b/jenkins/beta-testing-security-scan.sh
@@ -22,7 +22,7 @@ GRYPE_COMMIT_HASH="9fb219495a634d7ff9904154355b927223a66602"
 # Sets Syft to Pretty Print JSON Ouputs
 SYFT_FORMAT_JSON_PRETTY=true
 
-# (Severity Options: negligible, low, medium, high, critical)
+# (Severity Options: disabled, negligible, low, medium, high, critical)
 FAIL_ON_SEVERITY=$3
 
 # Build on Podman or Docker
@@ -140,10 +140,16 @@ $TMP_JOB_DIR/grype -v -o json --only-fixed "sbom:$WORKSPACE/artifacts/sbom-resul
     > $WORKSPACE/artifacts/vulnerability-results-fixable-${IMAGE}.json
 
 set +e
-$TMP_JOB_DIR/grype -v -o table --only-fixed --fail-on $FAIL_ON_SEVERITY "sbom:$WORKSPACE/artifacts/sbom-results-${IMAGE}.json" \
+FAIL_ON_ARG=""
+if [[ "$FAIL_ON_SEVERITY" != "disabled" ]]; then
+    FAIL_ON_ARG="--fail-on $FAIL_ON_SEVERITY"
+fi
+
+$TMP_JOB_DIR/grype -v -o table --only-fixed $FAIL_ON_ARG "sbom:$WORKSPACE/artifacts/sbom-results-${IMAGE}.json" \
     -c ${TMP_JOB_DIR}/grype-false-positives.yml \
     > $WORKSPACE/artifacts/vulnerability-results-fixable-${IMAGE}.txt
 TEST_RESULT=$?
+
 set -e
 if [ $TEST_RESULT -ne 0 ]; then
     echo '==============================================='

--- a/jenkins/security-scan-source-template.sh
+++ b/jenkins/security-scan-source-template.sh
@@ -12,7 +12,7 @@ set -exv
 IMAGE_NAME="my-app"
 DOCKERFILE_LOCATION="."
 
-# (Severity Options: negligible, low, medium, high, critical)
+# (Severity Options: disabled, negligible, low, medium, high, critical)
 FAIL_ON_SEVERITY="high"
 
 # Build on "podman" or "docker"

--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -16,7 +16,7 @@ GRYPE_COMMIT_HASH="9fb219495a634d7ff9904154355b927223a66602"
 # Sets Syft to Pretty Print JSON Ouputs
 SYFT_FORMAT_JSON_PRETTY=true
 
-# (Severity Options: negligible, low, medium, high, critical)
+# (Severity Options: disabled, negligible, low, medium, high, critical)
 FAIL_ON_SEVERITY=$3
 
 # Build on Podman or Docker
@@ -128,10 +128,16 @@ $TMP_JOB_DIR/grype -v -o json --only-fixed "sbom:$WORKSPACE/artifacts/sbom-resul
     > $WORKSPACE/artifacts/vulnerability-results-fixable-${IMAGE}.json
 
 set +e
-$TMP_JOB_DIR/grype -v -o table --only-fixed --fail-on $FAIL_ON_SEVERITY "sbom:$WORKSPACE/artifacts/sbom-results-${IMAGE}.json" \
+FAIL_ON_ARG=""
+if [[ "$FAIL_ON_SEVERITY" != "disabled" ]]; then
+    FAIL_ON_ARG="--fail-on $FAIL_ON_SEVERITY"
+fi
+
+$TMP_JOB_DIR/grype -v -o table --only-fixed $FAIL_ON_ARG "sbom:$WORKSPACE/artifacts/sbom-results-${IMAGE}.json" \
     -c ${TMP_JOB_DIR}/grype-false-positives.yml \
     > $WORKSPACE/artifacts/vulnerability-results-fixable-${IMAGE}.txt
 TEST_RESULT=$?
+
 set -e
 if [ $TEST_RESULT -ne 0 ]; then
     echo '==============================================='


### PR DESCRIPTION
## Overview

This PR adds the following:
- Added a new `Fail on Severity` Option (`disabled`) for the Jenkins Scan.
  - This allows teams to disable the `Fail on Severity` parameter if they wish to do so.


## Local Testing
- Update Jenkins Scripts were tested locally and are working as expected

## Summary by Sourcery

Add a 'disabled' option to Jenkins security scan scripts to allow skipping severity checks

Enhancements:
- Introduce a new 'disabled' severity option in Jenkins security scan scripts to provide more flexibility in vulnerability scanning

Chores:
- Update comments in security scan scripts to reflect the new severity option