### PR TITLE
Updating Max Grype DB Age to 10 days

### DIFF
--- a/.github/workflows/platsec-security-scan-reusable-workflow.yml
+++ b/.github/workflows/platsec-security-scan-reusable-workflow.yml
@@ -28,6 +28,9 @@ env:
   GRYPE_ARTIFACTS_DIR: $GRYPE_ARTIFACTS_DIR
   SYFT_ARTIFACTS_DIR: $SYFT_ARTIFACTS_DIR
   SYFT_FORMAT_JSON_PRETTY: true
+  # Max allowed age for vulnerability database, age being the time since it was built
+  # Default max age is 120h (or five days) (env: GRYPE_DB_MAX_ALLOWED_BUILT_AGE)
+  GRYPE_DB_MAX_ALLOWED_BUILT_AGE: 240h0m0s
 
 on:
   workflow_call:

--- a/jenkins/beta-testing-security-scan.sh
+++ b/jenkins/beta-testing-security-scan.sh
@@ -19,6 +19,10 @@ GRYPE_VERSION="v0.80.1"
 SYFT_COMMIT_HASH="fcd5ec951de6b3fc1f1aa2a36968356d2eb22170"
 GRYPE_COMMIT_HASH="9fb219495a634d7ff9904154355b927223a66602"
 
+# Max allowed age for vulnerability database, age being the time since it was built
+# Default max age is 120h (or five days) (env: GRYPE_DB_MAX_ALLOWED_BUILT_AGE)
+GRYPE_DB_MAX_ALLOWED_BUILT_AGE="240h0m0s"
+
 # Sets Syft to Pretty Print JSON Ouputs
 SYFT_FORMAT_JSON_PRETTY=true
 

--- a/jenkins/security-scan.sh
+++ b/jenkins/security-scan.sh
@@ -13,6 +13,10 @@ GRYPE_VERSION="v0.80.1"
 SYFT_COMMIT_HASH="fcd5ec951de6b3fc1f1aa2a36968356d2eb22170"
 GRYPE_COMMIT_HASH="9fb219495a634d7ff9904154355b927223a66602"
 
+# Max allowed age for vulnerability database, age being the time since it was built
+# Default max age is 120h (or five days) (env: GRYPE_DB_MAX_ALLOWED_BUILT_AGE)
+GRYPE_DB_MAX_ALLOWED_BUILT_AGE="240h0m0s"
+
 # Sets Syft to Pretty Print JSON Ouputs
 SYFT_FORMAT_JSON_PRETTY=true
 


### PR DESCRIPTION
## Overview

There is currently an issues is caused by an outage of the upstream SUSE DB (_Approximate start was Friday 2025-05-16. ETA fix, afternoon of 2025-05-21_). 
- [1] https://github.com/anchore/grype/issues/2674
- [2] https://bugzilla.suse.com/show_bug.cgi?id=1243337

The max age any data can be in the DB is 5 days (120h). So, it is jamming up the scans, because it is failing the DB age requirements.

This PR adds the following ENV VAR to the jobs to increase the max age for the DB data.
```
GRYPE_DB_MAX_ALLOWED_BUILT_AGE = 240h0m0s
```